### PR TITLE
Tech 15245 use sha1 digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - not released
+### Changed
+- Use Digest::SHA1 instead of Digest::SHA256 for hex_digest.
+
 ## [0.2.0] - 2023-05-16
 ### Fixed
 - Lua Numbers without decimals will now be converted to integer strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - not released
+## [0.3.0] - 2024-10-15
 ### Changed
 - Use Digest::SHA1 instead of Digest::SHA256 for hex_digest.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mock_redis_lua_extension2 (0.3.pre.zh.0)
+    mock_redis_lua_extension2 (0.3.0)
       mock_redis
       rufus-lua
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mock_redis_lua_extension2 (0.2.0)
+    mock_redis_lua_extension2 (0.3.pre.zh.0)
       mock_redis
       rufus-lua
 
@@ -10,7 +10,7 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    ffi (1.15.5)
+    ffi (1.17.0)
     method_source (1.0.0)
     mock_redis (0.28.0)
       ruby2_keywords

--- a/lib/mock_redis_lua_extension.rb
+++ b/lib/mock_redis_lua_extension.rb
@@ -52,7 +52,7 @@ module MockRedisLuaExtension
     when :load
       args.count == 1 or raise ArgumentError, "Invalid args: #{args.inspect}"
       script = args.first
-      Digest::SHA256.hexdigest(script).tap do |sha|
+      Digest::SHA1.hexdigest(script).tap do |sha|
         script_catalog[sha] = script
       end
     when :flush

--- a/lib/mock_redis_lua_extension/version.rb
+++ b/lib/mock_redis_lua_extension/version.rb
@@ -1,3 +1,3 @@
 module MockRedisLuaExtension
-  VERSION = "0.2.0".freeze
+  VERSION = "0.3.pre.zh.0".freeze
 end

--- a/lib/mock_redis_lua_extension/version.rb
+++ b/lib/mock_redis_lua_extension/version.rb
@@ -1,3 +1,3 @@
 module MockRedisLuaExtension
-  VERSION = "0.3.pre.zh.0".freeze
+  VERSION = "0.3.0".freeze
 end


### PR DESCRIPTION
Using SHA1 instead of SHA256 for script's hexdigest to match the expectations of the graphql-pro gem. 

That gem is a private/pro gem doesn't have a visible repo of source code, but I'll copy relevant code here. When it is registering its redis scripts, it uses a SHA1 hexdigest. 

```ruby
module GraphQL
  module Pro
    class RedisScriptClient
      class << self
        def register(name, operation)
          operations[name] = {
            source: operation,
            sha: Digest::SHA1.hexdigest(operation),
          }
        end
#...
```

Our mock_redis_lua_extension2 gem had been using SHA256, which results in [this error](https://buildkite.com/invoca/web/builds/89173#01927cef-b00a-4cdf-a8f9-f59efbcfa35d) in tests
```
RuntimeError:         RuntimeError: Invariant: Calculated SHA doesn't match Redis SHA ("e755f0271a42601cdab85ad6826cbacb17cd0474", "2a7e9e472a262d83c5c177aaad198d502767644939cf2e2d590620cda9ab6358")
```

Using a matching SHA/hexdigest will eliminate this error from tests (see clean build [here](https://buildkite.com/invoca/web/builds/89255#01928bb3-b5de-4703-a921-aeb793f901e0))
