### PR TITLE
TECH-15245: alias unpack to table.unpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - not released
+### Added
+- Added support for `unpack` as an alias for `table.unpack` to ensure compatability for old lua scripts running on new lua versions (> 5.1).
+
 ## [0.3.0] - 2024-10-15
 ### Changed
 - Use Digest::SHA1 instead of Digest::SHA256 for hex_digest.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mock_redis_lua_extension2 (0.3.0)
+    mock_redis_lua_extension2 (0.3.1.pre.0)
       mock_redis
       rufus-lua
 
@@ -10,7 +10,7 @@ GEM
   specs:
     coderay (1.1.3)
     diff-lcs (1.3)
-    ffi (1.17.0)
+    ffi (1.17.1)
     method_source (1.1.0)
     mock_redis (0.28.0)
       ruby2_keywords

--- a/lib/mock_redis_lua_extension.rb
+++ b/lib/mock_redis_lua_extension.rb
@@ -82,6 +82,8 @@ module MockRedisLuaExtension
     lua_state = Rufus::Lua::State.new
     setup_keys_and_argv(lua_state, keys, argv, args)
 
+    lua_state.eval('unpack = table.unpack')
+
     lua_state.function 'redis.call' do |cmd, *args|
       lua_bound_redis_call(cmd, *args)
     end

--- a/lib/mock_redis_lua_extension/version.rb
+++ b/lib/mock_redis_lua_extension/version.rb
@@ -1,3 +1,3 @@
 module MockRedisLuaExtension
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1.pre.0".freeze
 end

--- a/spec/mock_redis_lua_extension_spec.rb
+++ b/spec/mock_redis_lua_extension_spec.rb
@@ -75,6 +75,19 @@ RSpec.describe MockRedisLuaExtension, '::' do
         result = redis.eval('return KEYS[1]', keys: [:stuff])
         expect(result).to eq('stuff')
       end
+
+      it 'supports the unpack function, as equivalent to table.unpack' do
+        unpack_lua_script = '
+          local t = {1, 2, 3, 4, 5}
+          return {unpack(t, 2, 4)}
+        '.strip
+        table_unpack_lua_script = '
+          local t = {1, 2, 3, 4, 5}
+          return {table.unpack(t, 2, 4)}
+        '.strip
+        expect(redis.eval(unpack_lua_script)).to eq([2, 3, 4])
+        expect(redis.eval(table_unpack_lua_script)).to eq([2, 3, 4])
+      end
     end
 
     context 'marshalling lua args to redis.call' do


### PR DESCRIPTION
Adding an alias for `unpack` to `table.unpack` to ensure compatability for scripts written for lua 5.1 that are now being run on 5.4. Impetus for this change is test failures for Graphql Pro subscriptions in my web passion project (https://buildkite.com/invoca/web/builds/97869#0195ab45-a052-41d4-b039-d868b0815148)

From Lua 5.2 reference [manual](https://www.lua.org/manual/5.2/manual.html)
> Function unpack was moved into the table library and therefore must be called as table.unpack.