### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit
     with:
       pre-test-hook: "sudo apt-get install liblua5.1-0"
       test-command: "bundle exec rake"

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ group :development do
   gem 'pry'
   gem 'rake'
   gem 'rspec'
+  gem 'simplecov', '~> 0.22'
+  gem 'simplecov-lcov', '~> 0.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   specs:
     coderay (1.1.3)
     diff-lcs (1.3)
+    docile (1.4.1)
     ffi (1.17.0)
     method_source (1.1.0)
     mock_redis (0.28.0)
@@ -34,6 +35,13 @@ GEM
     ruby2_keywords (0.0.5)
     rufus-lua (1.1.5)
       ffi (~> 1.9)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   ruby
@@ -44,6 +52,8 @@ DEPENDENCIES
   pry
   rake
   rspec
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
 
 BUNDLED WITH
    2.3.9

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/spec/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require_relative "simplecov_helper"
+
 require 'pry'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
## Summary
- Pass secrets: inherit to the shared ruby-test-matrix workflow call in .github/workflows/pipeline.yml so the org CODECOV_TOKEN reaches the shared workflow's Codecov upload step
- Add spec/simplecov_helper.rb (required first in spec/spec_helper.rb) so the suite runs under SimpleCov, emitting coverage/lcov.info via simplecov-lcov when GITHUB_ACTIONS is set and HTML locally
- Add simplecov (~> 0.22) and simplecov-lcov (~> 0.8) to the Gemfile development group (this repo declares dev dependencies in the Gemfile, not the gemspec) and update Gemfile.lock

## Coverage
Measured locally with bundle exec rake on Ruby 3.1.6: Line Coverage: 86.92% (113 / 130). Verified coverage/lcov.info is generated with GITHUB_ACTIONS=true.

## codecov.yml
Not added: coverage is above the 80% threshold.